### PR TITLE
fixed python-3 error in range

### DIFF
--- a/pyext/src/exhaust.py
+++ b/pyext/src/exhaust.py
@@ -204,8 +204,8 @@ def main():
 
     # Get model lists
     if args.rmf_A is not None:
-        sampleA_all_models = range(n_models[0])
-        sampleB_all_models = range(n_models[0], n_models[1] + n_models[0])
+        sampleA_all_models = list(range(n_models[0]))
+        sampleB_all_models = list(range(n_models[0], n_models[1] + n_models[0]))
         total_num_models = n_models[1] + n_models[0]
     else:
         (sampleA_all_models,


### PR DESCRIPTION
range() returns a generator instead of an iterable in python-3, so two range objects can no longer be simply added. Instead they have to be converted to lists. 