### PR TITLE
Rmsd selection

### DIFF
--- a/pyext/src/exhaust.py
+++ b/pyext/src/exhaust.py
@@ -190,7 +190,8 @@ def main():
     else:
         args.extension = "rmf3"
         if args.selection is not None:
-            rmsd_custom_ranges = precision_rmsd.parse_custom_ranges(args.selection)
+            rmsd_custom_ranges = \
+                precision_rmsd.parse_custom_ranges(args.selection)
         else:
             rmsd_custom_ranges = None
         # If we have a single RMF file, read conformations from that

--- a/pyext/src/exhaust.py
+++ b/pyext/src/exhaust.py
@@ -92,7 +92,8 @@ def parse_args():
         action='store_true')
     parser.add_argument(
         '--selection', '-sn', dest="selection",
-        help='file containing dictionary of selected subunits and residues'
+        help='file containing dictionary'
+        'of selected subunits and residues'
         'for RMSD and clustering calculation'
         "each entry in the dictionary takes the form"
         "'selection name': [(residue_start, residue_end, protein name)",

--- a/pyext/src/exhaust.py
+++ b/pyext/src/exhaust.py
@@ -187,7 +187,10 @@ def main():
                 args.path, idfile_A, idfile_B)
     else:
         args.extension = "rmf3"
-        rmsd_custom_ranges = precision_rmsd.parse_custom_ranges(args.selection)
+        if args.selection is not None:
+            rmsd_custom_ranges = precision_rmsd.parse_custom_ranges(args.selection)
+        else:
+            rmsd_custom_ranges = None
         # If we have a single RMF file, read conformations from that
         if args.rmf_A is not None:
             (ps_names, masses, radii, conforms, symm_groups, models_name,

--- a/pyext/src/exhaust.py
+++ b/pyext/src/exhaust.py
@@ -90,6 +90,12 @@ def parse_args():
         '--gnuplot', '-gp', dest="gnuplot",
         help="plotting automatically with gnuplot", default=False,
         action='store_true')
+    parser.add_argument(
+        '--selection', '-sn', dest="selection",
+        help='file containing dictionary of selected subunits and residues'
+        'for RMSD and clustering calculation'
+        "each entry in the dictionary takes the form"
+        "'selection name': [(residue_start, residue_end, protein name)",default=None)
     return parser.parse_args()
 
 
@@ -181,19 +187,22 @@ def main():
                 args.path, idfile_A, idfile_B)
     else:
         args.extension = "rmf3"
+        rmsd_custom_ranges = precision_rmsd.parse_custom_ranges(args.selection)
         # If we have a single RMF file, read conformations from that
         if args.rmf_A is not None:
             (ps_names, masses, radii, conforms, symm_groups, models_name,
                 n_models) = rmsd_calculation.get_rmfs_coordinates_one_rmf(
-                     args.path, args.rmf_A, args.rmf_B, args.subunit,
-                     args.symmetry_groups)
+                     args.path, args.rmf_A, args.rmf_B, args.subunit, 
+                     args.symmetry_groups,
+                     rmsd_custom_ranges)
 
         # If not, default to the Identities.txt file
         else:
             symm_groups = None
             (ps_names, masses, radii, conforms,
              models_name) = rmsd_calculation.get_rmfs_coordinates(
-                     args.path, idfile_A, idfile_B, args.subunit)
+                     args.path, idfile_A, idfile_B, args.subunit, 
+                     selection=rmsd_custom_ranges)
 
     print("Size of conformation matrix", conforms.shape)
 

--- a/pyext/src/exhaust.py
+++ b/pyext/src/exhaust.py
@@ -95,7 +95,8 @@ def parse_args():
         help='file containing dictionary of selected subunits and residues'
         'for RMSD and clustering calculation'
         "each entry in the dictionary takes the form"
-        "'selection name': [(residue_start, residue_end, protein name)",default=None)
+        "'selection name': [(residue_start, residue_end, protein name)",
+        default=None)
     return parser.parse_args()
 
 
@@ -195,7 +196,7 @@ def main():
         if args.rmf_A is not None:
             (ps_names, masses, radii, conforms, symm_groups, models_name,
                 n_models) = rmsd_calculation.get_rmfs_coordinates_one_rmf(
-                     args.path, args.rmf_A, args.rmf_B, args.subunit, 
+                     args.path, args.rmf_A, args.rmf_B, args.subunit,
                      args.symmetry_groups,
                      rmsd_custom_ranges)
 
@@ -204,7 +205,7 @@ def main():
             symm_groups = None
             (ps_names, masses, radii, conforms,
              models_name) = rmsd_calculation.get_rmfs_coordinates(
-                     args.path, idfile_A, idfile_B, args.subunit, 
+                     args.path, idfile_A, idfile_B, args.subunit,
                      selection=rmsd_custom_ranges)
 
     print("Size of conformation matrix", conforms.shape)

--- a/pyext/src/rmsd_calculation.py
+++ b/pyext/src/rmsd_calculation.py
@@ -18,9 +18,8 @@ def parse_rmsd_selection(h, selection):
         # parse tuple selection in dictionary file for residue ranges
         s = IMP.atom.Selection(h, resolution=1,
                                molecule=str(selected_range[0][2]),
-                                            molecule=str(selected_range[0][2]),
-                                            residue_indexes=range(selected_range[0][0],
-                                            selected_range[0][1]))
+                               residue_indexes=range(selected_range[0][0],
+                                                     selected_range[0][1]))
         if idx == 0:
             s0 = s
         else:

--- a/pyext/src/rmsd_calculation.py
+++ b/pyext/src/rmsd_calculation.py
@@ -11,20 +11,22 @@ import IMP.atom
 import IMP.rmf
 import RMF
 
+
 def parse_rmsd_selection(h, selection):
-    s0=None
+    s0 = None
     for idx,selected_range in enumerate(selection.values()):
         if idx==0:
             s0 = IMP.atom.Selection(h, resolution=1,
-                    molecule=str(selected_range[0][2]), 
-                    residue_indexes=range(selected_range[0][0], 
+                    molecule = str(selected_range[0][2]),
+                    residue_indexes=range(selected_range[0][0],
                     selected_range[0][1]))
         else:
             s1 = IMP.atom.Selection(h, resolution=1,
-                    molecule=str(selected_range[0][2]),
+                    molecule = str(selected_range[0][2]),
                     residue_indexes=range(selected_range[0][0],
                     selected_range[0][1]))
             s0 = s0 | s1
+
     return s0
 
 def get_pdbs_coordinates(path, idfile_A, idfile_B):
@@ -261,6 +263,8 @@ def get_rmfs_coordinates_one_rmf(path, rmf_A, rmf_B, subunit_name=None,
             # names for symmetric copies
             if subunit_name:
                 s0 = IMP.atom.Selection(h, resolution=1, molecule=subunit_name)
+            elif selection is not None:
+                s0 = parse_rmsd_selection(h, selection)
             else:
                 s0 = IMP.atom.Selection(h, resolution=1)
 

--- a/pyext/src/rmsd_calculation.py
+++ b/pyext/src/rmsd_calculation.py
@@ -15,18 +15,16 @@ import RMF
 def parse_rmsd_selection(h, selection):
     s0 = None
     for idx,selected_range in enumerate(selection.values()):
+        # parse tuple selection in dictionary file for residue ranges
+        s = IMP.atom.Selection(h, resolution=1,
+                               molecule=str(selected_range[0][2]),
+                                            molecule=str(selected_range[0][2]),
+                                            residue_indexes=range(selected_range[0][0],
+                                            selected_range[0][1]))
         if idx == 0:
-            #parse tuple selection in dictionary file for residue ranges
-            s0 = IMP.atom.Selection(h, resolution=1,
-                                    molecule=str(selected_range[0][2]),
-                                    residue_indexes=range(selected_range[0][0],
-                                    selected_range[0][1]))
+            s0 = s
         else:
-            s1 = IMP.atom.Selection(h, resolution=1,
-                                    molecule=str(selected_range[0][2]),
-                                    residue_indexes=range(selected_range[0][0],
-                                    selected_range[0][1]))
-            s0 = s0 | s1
+            s0 |= s
 
     return s0
 
@@ -189,7 +187,6 @@ def parse_symmetric_groups_file(symm_groups_file):
 def get_rmfs_coordinates_one_rmf(path, rmf_A, rmf_B, subunit_name=None,
                                  symm_groups_file=None, selection=None):
     '''Modified RMF coordinates function to work with symmetric copies'''
-
 
     # Open RMFs and get total number of models
     rmf_fh = RMF.open_rmf_file_read_only(os.path.join(path, rmf_A))

--- a/pyext/src/rmsd_calculation.py
+++ b/pyext/src/rmsd_calculation.py
@@ -11,6 +11,21 @@ import IMP.atom
 import IMP.rmf
 import RMF
 
+def parse_rmsd_selection(h, selection):
+    s0=None
+    for idx,selected_range in enumerate(selection.values()):
+        if idx==0:
+            s0 = IMP.atom.Selection(h, resolution=1,
+                    molecule=str(selected_range[0][2]), 
+                    residue_indexes=range(selected_range[0][0], 
+                    selected_range[0][1]))
+        else:
+            s1 = IMP.atom.Selection(h, resolution=1,
+                    molecule=str(selected_range[0][2]),
+                    residue_indexes=range(selected_range[0][0],
+                    selected_range[0][1]))
+            s0 = s0 | s1
+    return s0
 
 def get_pdbs_coordinates(path, idfile_A, idfile_B):
     pts = []
@@ -90,19 +105,7 @@ def get_rmfs_coordinates(path, idfile_A, idfile_B, subunit_name=None, selection=
             if subunit_name:
                 s0 = IMP.atom.Selection(h, resolution=1, molecule=subunit_name)
             elif selection is not None:
-                s0=None
-                for idx,selected_range in enumerate(selection.values()):
-                    if idx==0:
-                        s0 = IMP.atom.Selection(h, resolution=1,
-                                molecule=str(selected_range[0][2]), 
-                                residue_indexes=range(selected_range[0][0], 
-                                selected_range[0][1]))
-                    else:
-                        s1 = IMP.atom.Selection(h, resolution=1,
-                                molecule=str(selected_range[0][2]), 
-                                residue_indexes=range(selected_range[0][0], 
-                                selected_range[0][1]))
-                        s0 = s0 | s1
+                s0 = parse_rmsd_selection(h, selection)
             else:
                 s0 = IMP.atom.Selection(h, resolution=1)
 
@@ -210,19 +213,7 @@ def get_rmfs_coordinates_one_rmf(path, rmf_A, rmf_B, subunit_name=None,
     if subunit_name:
         s0 = IMP.atom.Selection(h, resolution=1, molecule=subunit_name)
     elif selection:
-        s0=None
-        for idx,selected_range in enumerate(selection.values()):
-            if idx==0:
-                s0 = IMP.atom.Selection(h, resolution=1,
-                        molecule=str(selected_range[0][2]), 
-                        residue_indexes=range(selected_range[0][0], 
-                        selected_range[0][1]))
-            else:
-                s1 = IMP.atom.Selection(h, resolution=1,
-                        molecule=str(selected_range[0][2]), 
-                        residue_indexes=range(selected_range[0][0], 
-                        selected_range[0][1]))
-                s0 = s0 | s1
+        s0 = parse_rmsd_selection(h, selection)
     else:
         s0 = IMP.atom.Selection(h, resolution=1)
 

--- a/pyext/src/rmsd_calculation.py
+++ b/pyext/src/rmsd_calculation.py
@@ -59,7 +59,7 @@ def get_pdbs_coordinates(path, idfile_A, idfile_B):
     return np.array(conform), masses, radii, models_name
 
 
-def get_rmfs_coordinates(path, idfile_A, idfile_B, subunit_name):
+def get_rmfs_coordinates(path, idfile_A, idfile_B, subunit_name=None, selection=None):
 
     conform = []
     num = 0
@@ -89,6 +89,20 @@ def get_rmfs_coordinates(path, idfile_A, idfile_B, subunit_name):
 
             if subunit_name:
                 s0 = IMP.atom.Selection(h, resolution=1, molecule=subunit_name)
+            elif selection:
+                s0=None
+                for idx,selected_range in enumerate(selection.values()):
+                    if idx==0:
+                        s0 = IMP.atom.Selection(h, resolution=1,
+                                molecule=str(selected_range[0][2]), 
+                                residue_indexes=range(selected_range[0][0], 
+                                selected_range[0][1]))
+                    else:
+                        s1 = IMP.atom.Selection(h, resolution=1,
+                                molecule=str(selected_range[0][2]), 
+                                residue_indexes=range(selected_range[0][0], 
+                                selected_range[0][1]))
+                        s0 = s0 | s1
             else:
                 s0 = IMP.atom.Selection(h, resolution=1)
 
@@ -166,8 +180,8 @@ def parse_symmetric_groups_file(symm_groups_file):
 
 
 def get_rmfs_coordinates_one_rmf(path, rmf_A, rmf_B, subunit_name=None,
-                                 symm_groups_file=None):
-
+                                 symm_groups_file=None, selection=None):
+ 
     '''Modified RMF coordinates function to work with symmetric copies'''
 
     # Open RMFs and get total number of models
@@ -195,6 +209,20 @@ def get_rmfs_coordinates_one_rmf(path, rmf_A, rmf_B, subunit_name=None,
     # Get selection
     if subunit_name:
         s0 = IMP.atom.Selection(h, resolution=1, molecule=subunit_name)
+    if selection:
+        s0=None
+        for idx,selected_range in enumerate(selection.values()):
+            if idx==0:
+                s0 = IMP.atom.Selection(h, resolution=1,
+                        molecule=str(selected_range[0][2]), 
+                        residue_indexes=range(selected_range[0][0], 
+                        selected_range[0][1]))
+            else:
+                s1 = IMP.atom.Selection(h, resolution=1,
+                        molecule=str(selected_range[0][2]), 
+                        residue_indexes=range(selected_range[0][0], 
+                        selected_range[0][1]))
+                s0 = s0 | s1
     else:
         s0 = IMP.atom.Selection(h, resolution=1)
 

--- a/pyext/src/rmsd_calculation.py
+++ b/pyext/src/rmsd_calculation.py
@@ -15,16 +15,17 @@ import RMF
 def parse_rmsd_selection(h, selection):
     s0 = None
     for idx,selected_range in enumerate(selection.values()):
-        if idx==0:
+        if idx == 0:
+            #parse tuple selection in dictionary file for residue ranges
             s0 = IMP.atom.Selection(h, resolution=1,
-                    molecule = str(selected_range[0][2]),
-                    residue_indexes=range(selected_range[0][0],
-                    selected_range[0][1]))
+                                    molecule=str(selected_range[0][2]),
+                                    residue_indexes=range(selected_range[0][0],
+                                    selected_range[0][1]))
         else:
             s1 = IMP.atom.Selection(h, resolution=1,
-                    molecule = str(selected_range[0][2]),
-                    residue_indexes=range(selected_range[0][0],
-                    selected_range[0][1]))
+                                    molecule=str(selected_range[0][2]),
+                                    residue_indexes=range(selected_range[0][0],
+                                    selected_range[0][1]))
             s0 = s0 | s1
 
     return s0
@@ -76,7 +77,8 @@ def get_pdbs_coordinates(path, idfile_A, idfile_B):
     return np.array(conform), masses, radii, models_name
 
 
-def get_rmfs_coordinates(path, idfile_A, idfile_B, subunit_name=None, selection=None):
+def get_rmfs_coordinates(path, idfile_A, idfile_B,
+                         subunit_name=None, selection=None):
 
     conform = []
     num = 0
@@ -186,8 +188,8 @@ def parse_symmetric_groups_file(symm_groups_file):
 
 def get_rmfs_coordinates_one_rmf(path, rmf_A, rmf_B, subunit_name=None,
                                  symm_groups_file=None, selection=None):
- 
     '''Modified RMF coordinates function to work with symmetric copies'''
+
 
     # Open RMFs and get total number of models
     rmf_fh = RMF.open_rmf_file_read_only(os.path.join(path, rmf_A))

--- a/pyext/src/rmsd_calculation.py
+++ b/pyext/src/rmsd_calculation.py
@@ -89,7 +89,7 @@ def get_rmfs_coordinates(path, idfile_A, idfile_B, subunit_name=None, selection=
 
             if subunit_name:
                 s0 = IMP.atom.Selection(h, resolution=1, molecule=subunit_name)
-            elif selection:
+            elif selection is not None:
                 s0=None
                 for idx,selected_range in enumerate(selection.values()):
                     if idx==0:

--- a/pyext/src/rmsd_calculation.py
+++ b/pyext/src/rmsd_calculation.py
@@ -212,7 +212,7 @@ def get_rmfs_coordinates_one_rmf(path, rmf_A, rmf_B, subunit_name=None,
     # Get selection
     if subunit_name:
         s0 = IMP.atom.Selection(h, resolution=1, molecule=subunit_name)
-    elif selection:
+    elif selection is not None:
         s0 = parse_rmsd_selection(h, selection)
     else:
         s0 = IMP.atom.Selection(h, resolution=1)

--- a/pyext/src/rmsd_calculation.py
+++ b/pyext/src/rmsd_calculation.py
@@ -14,7 +14,7 @@ import RMF
 
 def parse_rmsd_selection(h, selection):
     s0 = None
-    for idx,selected_range in enumerate(selection.values()):
+    for idx, selected_range in enumerate(selection.values()):
         # parse tuple selection in dictionary file for residue ranges
         s = IMP.atom.Selection(h, resolution=1,
                                molecule=str(selected_range[0][2]),
@@ -26,6 +26,7 @@ def parse_rmsd_selection(h, selection):
             s0 |= s
 
     return s0
+
 
 def get_pdbs_coordinates(path, idfile_A, idfile_B):
     pts = []

--- a/pyext/src/rmsd_calculation.py
+++ b/pyext/src/rmsd_calculation.py
@@ -209,7 +209,7 @@ def get_rmfs_coordinates_one_rmf(path, rmf_A, rmf_B, subunit_name=None,
     # Get selection
     if subunit_name:
         s0 = IMP.atom.Selection(h, resolution=1, molecule=subunit_name)
-    if selection:
+    elif selection:
         s0=None
         for idx,selected_range in enumerate(selection.values()):
             if idx==0:


### PR DESCRIPTION
The patch adds selection for RMSD calculation of residue ranges. the --selection flag reads in a dictionary file with residue ranges.
The format of the selection file is a more limited than density_custom_ranges file because i used tuple parsing. 

So the selection file has to besomething like 

`density_custom_ranges = {"P75591_N":[(11,140,"P75591")], "P75591_KH": [(218, 358, "P75591")], "P75591_S1":[(148,209,"P75591")]}`

using residue ranges also to select full proteins
