### PR TITLE
Several minor changes to imp-sampcon

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The protocol is typically run using the `imp_sampcon` command line tool:
    sampling was exhaustive.
 
 For a full demonstration of the protocol, see its usage in
-IMP's [actin modeling tutorial](https://integrativemodeling.org/tutorials/actin/analysis.html) and [RNA Polymerase 2 tutorial](https://github.com/salilab/imp_analysis_tutorial).
+IMP's [actin modeling tutorial](https://integrativemodeling.org/tutorials/actin/analysis.html).
 
 # Selecting models for exhaustiveness test
 
@@ -57,7 +57,7 @@ Once the final thresholds are obtained, one can use `select_good` in EXTRACT mod
 
 # Running the exhaustiveness test
 
-See the usage of `exhaust` in IMP's [actin modeling tutorial](https://integrativemodeling.org/tutorials/actin/analysis.html) and [RNA Polymerase 2 tutorial](https://github.com/salilab/imp_analysis_tutorial).
+See the usage of `exhaust` in IMP's [actin modeling tutorial](https://integrativemodeling.org/tutorials/actin/analysis.html).
 
 ## Outputs
 
@@ -107,7 +107,7 @@ Voxel (`-v`) and density threshold (`-dt`) input options are related to density 
 
 The protocol can also handle systems with ambiguity and symmetry (e.g. multiple protein copies whose positions can be interchanged), where this information needs to be considered while calculating the RMSD between models. The RMSD between two protein models is the minimum RMSD over permutations of equivalent proteins.
 
-** Note **: You only need to use this option if your protein copies are symmetric, i.e. they are interchangeable in the model. If there are multiple copies but they occupy distinct positions in the model, this option will not be useful and will give the same result as regular `exhaust` without ambiguity option.
+**Note**: You only need to use this option if your protein copies are symmetric, i.e. they are interchangeable in the model. If there are multiple copies but they occupy distinct positions in the model, this option will not be useful and will give the same result as regular `exhaust` without ambiguity option.
 
 #### Example
 If a system has 2 copies of protein A and 1 copy of protein B, i.e. the proteins are A.0, A.1,B.0. The RMSD between any pair of models m0 and m1, is the minimum RMSD between `RMSD[m0(A.0,A.1,B.0) , m1(A.0,A.1,B.1)]` and `RMSD[m0(A.0,A.1,B.1), m1(A.1,A.0,B.1]`. Note that the copies of A in m1 were interchanged while calculating the second RMSD.

--- a/README.md
+++ b/README.md
@@ -33,17 +33,85 @@ The protocol is typically run using the `imp_sampcon` command line tool:
    sampling was exhaustive.
 
 For a full demonstration of the protocol, see its usage in
-IMP's [actin modeling tutorial](https://integrativemodeling.org/tutorials/actin/analysis.html).
+IMP's [actin modeling tutorial](https://integrativemodeling.org/tutorials/actin/analysis.html) and [RNA Polymerase 2 tutorial](https://github.com/salilab/imp_analysis_tutorial).
 
-## Ambiguity:
+# Selecting models for exhaustiveness test
 
-The protocol can also handle systems with ambiguity (equivalent proteins,
-e.g. multiple protein copies), where this information needs to be considered
-while calculating the RMSD between models. The RMSD between two protein
-models is the minimum RMSD over permutations of equivalent proteins.
+[PMI analysis](https://github.com/salilab/PMI_analysis/) is the current way to select models for the exhaustiveness test. It selects models based on MCMC equilibration and HDBSCAN density-based clustering of model scores.
 
-For example, if a system has 2 copies of protein A and 1 copy of protein B, i.e. the proteins are A.0, A.1,B.0. The RMSD between any pair of models m0 and m1, is the minimum RMSD between `RMSD[m0(A.0,A.1,B.0) , m1(A.0,A.1,B.1)]` and `RMSD[m0(A.0,A.1,B.1), m1(A.1,A.0,B.1]`. Note that the copies of A in m1 were interchanged while calculating the second RMSD. 
+In this module, we also have scripts for an earlier method to select models based on thresholds on score terms.
 
-To implement this, pyRMSD takes an additional argument `symm_groups` which is a list of particle indices of equivalent particles. For the above case for instance, `symm_groups` has one symmetric group with the particle indices of A.0 and A.1. `symm_groups=[[[A.0.b0,A.1.b0],[A.0.b1,A.1.b1],[A.0.b2,A.1.b2]..[A.0.bn,A.1.bn]]]`. Here `A.X.bi` is the index of the i'th bead in protein A.X and the ith beads of the two protein copies are considered equivalent particles. 
+`select_good`  selects a set of good-scoring models based on user-specified score thresholds. The options are described in detail in the [actin modeling tutorial](https://salilab.org/pdf/Saltzberg_MethodsMolBiol_2019.pdf).
 
-To generate this list of symmetric groups, one needs to pass an additional file with the ambiguity option to the master exhaust script. The file contains one line per symmetric group, and components of symmetric groups are separated by white space. See also the example in symminput. 
+A few things to note:
+
+1. How does one set score thresholds? `select_good` has two modes to help with this.
+First, one can just guess the values of lower and upper thresholds of score terms based on individual stat files from sampling and use `select_good` in FILTER mode (i.e. without -e option) to see how many models one can get with the current thresholds. One can also plot these scores using `plot_score` to aid in refining the thresholds.
+Once the final thresholds are obtained, one can use `select_good` in EXTRACT mode (i.e. with -e option) to extract the corresponding RMFs.
+
+2. `-alt` and `-aut` (aggregate lower and upper thresholds) are the lower threshold and upper thresholds to be set for most score terms like `Total_Score`. `-mlt` and `-mut` (member lower and upper thresholds) only need to be set for crosslinks when specifying distance thresholds for each type of crosslink.
+
+3. `-sl` (selection list) specifies which scores are selected based on specified thresholds and `-pl`(print list) is the extra set of scores that will be printed for each selected model. If a score term is already in the selection list it need not be specified in the print list. Currently, empty print lists are not allowed.
+
+4. The script assumes the output stat files from sampling are in `$run_directory/$run_prefix*/output` where $run_directory and $run_prefix are specified by `-rd` and `-rp`.
+
+# Running the exhaustiveness test
+
+See the usage of `exhaust` in IMP's [actin modeling tutorial](https://integrativemodeling.org/tutorials/actin/analysis.html) and [RNA Polymerase 2 tutorial](https://github.com/salilab/imp_analysis_tutorial).
+
+## Outputs
+
+The output includes
+
+* *Convergence of top score file* : `*.Top_Score_Conv.txt` contains the average and standard deviation of the top score (second and third columns) obtained by random subsets of size 10%, 20% …. 100% of the total number of models (first column).
+* *Difference in score distributions* : `*.Score_Hist_*.txt` stores the histogram of score distributions and `*.KS_test.txt` contains the effect size D and p-value from the KS test.
+* *Chi-square test* : `rnapol.ChiSquare_Grid_Stats.txt` contains for each clustering threshold (first column), the p-value, Cramer’s V and population of models in the contingency table (second, third and last columns). `rnapol.Sampling_Precision_Stats.txt` contains the value of sampling precision and the p-value, Cramer’s V and population of models at the sampling precision.
+
+PDF files are generated for results of the above tests if the gnuplot option is specified (`-gp`).
+
+* *Clusters* :
+A directory is created for each cluster (`cluster.0`, `cluster.1` and so on). The indices of models belonging to each cluster x are listed in `cluster.x.all.txt`, and listed by sample  in `cluster.x.sample_A.txt` and `cluster.x.sample_B.txt`.
+Cluster populations are in `rnapol.Cluster_Population.txt`, showing the number of models in samples A (second column) and B (third column) in each cluster (first column).
+Cluster precisions are in `rnapol.Cluster_Precision.txt`, with the precision defined by the average RMSD to the cluster centroid.
+The individual cluster directories contain representative bead models and localization densities.
+
+## Special input options
+Here a few special cases of `exhaust` are mentioned.
+
+### Clustering without sampling precision calculation
+Sometimes one would like to simply obtain clusters given a threshold, without going through the sampling precision calculation. For example, this could be because the user has already run `exhaust` once on the same input and found too many clusters at the sampling precision and would like to visualize a smaller number of clusters by clustering at a threshold worse than the sampling precision. In this case, one can use the `-s -ct <threshold>` options to skip the expensive steps of distance matrix generation and sampling precision calculation and directly cluster models at the given threshold.
+
+### Alignment
+This is usually not necessary if the sampling uses an EM map to place the complex. One must not align when specifying the subunit or a selected set of particles (`-su` or `-sn` option), since the reference frame will be specified by the fixed particles.
+
+### Doing the clustering, RMSD, and precision calculation on selected subunits
+By default, `exhaust` considers all subunits for RMSD and clustering. There are a couple of options to specify one or more subunits in particular.
+To select a single subunit `-su` option can be used.
+To select multiple subunits or domains of subunits, `-sn` option can be used. Protein domains can be specified with start and end residue numbers. Full proteins can also be specified without start and end residues. Each selection is listed as an entry in a dictionary called `density_custom_ranges` in a text file, like in the following example.
+```
+density_custom_ranges = {"Rpb4":[(1,200,"Rpb4")],"Rpb7":[("Rpb7")],"Rpb11-Rpb14-subcomplex":[("Rpb11"),("Rpb14")]}
+```
+If there are multiple protein copies, to specify copy number in the protein name the format `prot.copy_number` must be used. For example:
+```
+density_custom_ranges = {"Rpb4":[(1,200,"Rpb4.0")],"Rpb7.1":[(1,710,"Rpb7.1")]}
+```
+
+Note that one usually does not align (`-a`) when specifying select subunits, since the frame of reference is determined by the fixed subunits.
+
+### Getting localization densities
+A density file must be specified. The syntax is identical to the selection text file above (`-sn`). The output will contain MRC files, one per element of the dictionary in the density file.
+
+Voxel (`-v`) and density threshold (`-dt`) input options are related to density generation.
+
+### Symmetry and ambiguity
+
+The protocol can also handle systems with ambiguity and symmetry (e.g. multiple protein copies whose positions can be interchanged), where this information needs to be considered while calculating the RMSD between models. The RMSD between two protein models is the minimum RMSD over permutations of equivalent proteins.
+
+** Note **: You only need to use this option if your protein copies are symmetric, i.e. they are interchangeable in the model. If there are multiple copies but they occupy distinct positions in the model, this option will not be useful and will give the same result as regular `exhaust` without ambiguity option.
+
+#### Example
+If a system has 2 copies of protein A and 1 copy of protein B, i.e. the proteins are A.0, A.1,B.0. The RMSD between any pair of models m0 and m1, is the minimum RMSD between `RMSD[m0(A.0,A.1,B.0) , m1(A.0,A.1,B.1)]` and `RMSD[m0(A.0,A.1,B.1), m1(A.1,A.0,B.1]`. Note that the copies of A in m1 were interchanged while calculating the second RMSD.
+
+To implement this, pyRMSD takes an additional argument `symm_groups` which is a list of particle indices of equivalent particles. For the above case for instance, `symm_groups` has one symmetric group with the particle indices of A.0 and A.1. `symm_groups=[[[A.0.b0,A.1.b0],[A.0.b1,A.1.b1],[A.0.b2,A.1.b2]..[A.0.bn,A.1.bn]]]`. Here `A.X.bi` is the index of the i'th bead in protein A.X and the ith beads of the two protein copies are considered equivalent particles.
+
+To generate this list of symmetric groups, one needs to pass an additional file with the ambiguity option to the master exhaust script. The file contains one line per symmetric group, and components of symmetric groups are separated by white space. See also the example in `symminput`.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This is usually not necessary if the sampling uses an EM map to place the comple
 ### Doing the clustering, RMSD, and precision calculation on selected subunits
 By default, `exhaust` considers all subunits for RMSD and clustering. There are a couple of options to specify one or more subunits in particular.
 To select a single subunit `-su` option can be used.
-To select multiple subunits or domains of subunits, `-sn` option can be used. Protein domains can be specified with start and end residue numbers. Full proteins can also be specified without start and end residues. Each selection is listed as an entry in a dictionary called `density_custom_ranges` in a text file, like in the following example.
+To select multiple subunits or domains of subunits, `-sn` option can be used. Protein domains are specified with start and end residue numbers. Each selection is listed as an entry in a dictionary called `density_custom_ranges` in a text file, like in the following example.
 ```
 density_custom_ranges = {"Rpb4":[(1,200,"Rpb4")],"Rpb7":[("Rpb7")],"Rpb11-Rpb14-subcomplex":[("Rpb11"),("Rpb14")]}
 ```

--- a/pyext/src/exhaust.py
+++ b/pyext/src/exhaust.py
@@ -33,6 +33,10 @@ def parse_args():
         help='number of cores for RMSD matrix calculations; '
              'only for cpu_omp', default=1)
     parser.add_argument(
+        '--resolution', '-r', dest="resolution",type=int,
+        help='resolution at which to select proteins in a multiscale system',
+        default=1)
+    parser.add_argument(
         '--subunit', '-su', dest="subunit",
         help='calculate RMSD/sampling and cluster precision/densities '
              'etc over this subunit only', default=None)
@@ -198,7 +202,7 @@ def main():
         if args.rmf_A is not None:
             (ps_names, masses, radii, conforms, symm_groups, models_name,
                 n_models) = rmsd_calculation.get_rmfs_coordinates_one_rmf(
-                     args.path, args.rmf_A, args.rmf_B, args.subunit,
+                     args.path, args.rmf_A, args.rmf_B, args.resolution, args.subunit,
                      args.symmetry_groups,
                      rmsd_custom_ranges)
 
@@ -207,7 +211,7 @@ def main():
             symm_groups = None
             (ps_names, masses, radii, conforms,
              models_name) = rmsd_calculation.get_rmfs_coordinates(
-                     args.path, idfile_A, idfile_B, args.subunit,
+                     args.path, idfile_A, idfile_B, args.resolution,args.subunit,
                      selection=rmsd_custom_ranges)
 
     print("Size of conformation matrix", conforms.shape)

--- a/test/input/selection.txt
+++ b/test/input/selection.txt
@@ -1,0 +1,1 @@
+density_custom_ranges={"TestAll":[(1,20,'Rpb1')]}

--- a/test/medium_test_exhaust.py
+++ b/test/medium_test_exhaust.py
@@ -1,4 +1,6 @@
+import unittest
 import subprocess
+import sys
 import os
 import shutil
 import IMP.atom
@@ -31,8 +33,7 @@ class Tests(IMP.test.TestCase):
         mod_dir = os.path.join(tmpdir, 'modeling')
         shutil.copytree(self.get_input_file_name('modeling'), mod_dir)
 
-        self.run_python_module(
-            select_good,
+        self.run_python_module(select_good,
             ['-rd', mod_dir, '-rp', 'run',
              '-sl', 'CrossLinkingMassSpectrometryRestraint_Distance_',
              '-pl', 'ConnectivityRestraint_Rpb1',
@@ -42,30 +43,25 @@ class Tests(IMP.test.TestCase):
              '-e'])
         if make_rmf:
             gsm_dir = os.path.join(mod_dir, 'good_scoring_models')
-
             def read_sample(subdir):
-                return sorted(
-                    '%s/%s' % (subdir, rmf)
-                    for rmf in os.listdir(os.path.join(gsm_dir, subdir))
-                    if rmf.endswith('.rmf3'))
-            subprocess.check_call(
-                ['rmf_cat'] + read_sample('sample_A') + ['A.rmf3'],
-                cwd=gsm_dir)
-            subprocess.check_call(
-                ['rmf_cat'] + read_sample('sample_B') + ['B.rmf3'],
-                cwd=gsm_dir)
+                return sorted('%s/%s' % (subdir, rmf)
+                        for rmf in os.listdir(os.path.join(gsm_dir, subdir))
+                        if rmf.endswith('.rmf3'))
+            subprocess.check_call(['rmf_cat'] + read_sample('sample_A')
+                    + ['A.rmf3'], cwd=gsm_dir)
+            subprocess.check_call(['rmf_cat'] + read_sample('sample_B')
+                    + ['B.rmf3'], cwd=gsm_dir)
 
     def test_exhaust(self):
         """Test the master sampling exhaustiveness script"""
         try:
-            import pyRMSD  # noqa: F401
+            import pyRMSD
         except ImportError:
             self.skipTest("this test requires the pyRMSD Python module")
         with IMP.test.temporary_working_directory() as tmpdir:
             self.make_models(tmpdir)
             gsm_dir = os.path.join(tmpdir, 'modeling', 'good_scoring_models')
-            self.run_python_module(
-                exhaust,
+            self.run_python_module(exhaust,
                 ['-n', 'test', '-p', gsm_dir,
                  '-d', self.get_input_file_name('density_ranges.txt'),
                  '-m', 'cpu_omp', '-c', '8', '-a', '-g', '0.5', '-gp'])
@@ -120,14 +116,13 @@ class Tests(IMP.test.TestCase):
     def test_exhaust_rmf_a_b(self):
         "Test the master sampling exhaustiveness script with rmf_A,B options"
         try:
-            import pyRMSD  # noqa: F401
+            import pyRMSD
         except ImportError:
             self.skipTest("this test requires the pyRMSD Python module")
         with IMP.test.temporary_working_directory() as tmpdir:
             self.make_models(tmpdir, make_rmf=True)
             gsm_dir = os.path.join(tmpdir, 'modeling', 'good_scoring_models')
-            self.run_python_module(
-                exhaust,
+            self.run_python_module(exhaust,
                 ['-n', 'test', '-p', gsm_dir,
                  '-ra', 'A.rmf3', '-rb', 'B.rmf3',
                  '-d', self.get_input_file_name('density_ranges.txt'),
@@ -155,18 +150,55 @@ class Tests(IMP.test.TestCase):
             os.rmdir(os.path.join(tmpdir, 'cluster.0', 'Sample_B'))
             os.rmdir(os.path.join(tmpdir, 'cluster.0'))
 
+    def test_exhaust_selection_resolution(self):
+        "Test the master sampling exhaustiveness script with selection and resolution options"
+        try:
+            import pyRMSD
+        except ImportError:
+            self.skipTest("this test requires the pyRMSD Python module")
+        with IMP.test.temporary_working_directory() as tmpdir:
+            self.make_models(tmpdir, make_rmf=True)
+            gsm_dir = os.path.join(tmpdir, 'modeling', 'good_scoring_models')
+            self.run_python_module(exhaust,
+                ['-n', 'test', '-p', gsm_dir,
+                 '-ra', 'A.rmf3', '-rb', 'B.rmf3',
+                 '-sn', self.get_input_file_name('selection.txt'),
+                 '-r','1','-d', self.get_input_file_name('selection.txt'),
+                 '-m', 'cpu_omp', '-c', '8', '-g', '0.5', '-gp'])
+
+            # Check for expected files
+            expected = [
+                'Distances_Matrix.data.npy', 'cluster.0.all.txt',
+                'cluster.0.sample_A.txt',
+                'cluster.0.sample_B.txt', 'test.ChiSquare.pdf',
+                'test.ChiSquare_Grid_Stats.txt', 'test.Cluster_Population.pdf',
+                'test.Cluster_Population.txt', 'test.Cluster_Precision.txt',
+                'test.KS_Test.txt', 'test.Sampling_Precision_Stats.txt',
+                'test.Score_Dist.pdf', 'test.Score_Hist_A.txt',
+                'test.Score_Hist_B.txt', 'test.Top_Score_Conv.pdf',
+                'test.Top_Score_Conv.txt',
+                'cluster.0/cluster_center_model.rmf3',
+                'cluster.0/LPD_TestAll.mrc',
+                'cluster.0/Sample_A/LPD_TestAll.mrc',
+                'cluster.0/Sample_B/LPD_TestAll.mrc']
+
+            for e in expected:
+                os.unlink(os.path.join(tmpdir, e))
+            os.rmdir(os.path.join(tmpdir, 'cluster.0', 'Sample_A'))
+            os.rmdir(os.path.join(tmpdir, 'cluster.0', 'Sample_B'))
+            os.rmdir(os.path.join(tmpdir, 'cluster.0'))
+
     def test_exhaust_pdb(self):
         """Test the master sampling exhaustiveness script with PDBs"""
         try:
-            import pyRMSD  # noqa: F401
+            import pyRMSD
         except ImportError:
             self.skipTest("this test requires the pyRMSD Python module")
         with IMP.test.temporary_working_directory() as tmpdir:
             self.make_models(tmpdir)
             make_pdbs_from_rmfs(tmpdir)
             gsm_dir = os.path.join(tmpdir, 'modeling', 'good_scoring_models')
-            self.run_python_module(
-                exhaust,
+            self.run_python_module(exhaust,
                 ['-n', 'test', '-p', gsm_dir,
                  '-d', self.get_input_file_name('density_ranges.txt'),
                  '-m', 'cpu_omp', '-c', '8', '-a', '-g', '0.5', '-e', 'pdb'])

--- a/test/test_rmsd_calculation.py
+++ b/test/test_rmsd_calculation.py
@@ -105,8 +105,10 @@ class Tests(IMP.test.TestCase):
              "./",
              self.get_input_file_name("SampledA.rmf3"),
              self.get_input_file_name("SampledC.rmf3"),
+             1,
              None,
-             symmetry)
+             symmetry,
+             None)
 
         inner_data = rmsd_calculation.get_rmsds_matrix(  # noqa
             conforms, 'cpu_omp', align, 2, symm_groups)


### PR DESCRIPTION
This PR makes the following changes
1. A more comprehensive README file explaining some options in exhaust. 
2. Enhancements to selection option (issue #10). The selection text file is identical in format to the density file. Following features were added: A. Support for ambiguous proteins by adding code to get copy number for the selection B. Support for grouping multiple protein domains in a single key (e.g. when these form a subcomplex). 
3. Added test for selection code by Andrea (issue #10). 
4. Added option to select beads by a user-specified resolution (requested by Jan Kosinski on imp-developers list). Enhances efficiency for multi-scale systems. 
5. Added warning when symmetry lists are empty and ambiguity option is specified (See Ilan’s issue #14 ). 
