### PR TITLE
prevent un-necessary recalculation of RMSD matrix

### DIFF
--- a/pyext/src/exhaust.py
+++ b/pyext/src/exhaust.py
@@ -218,16 +218,20 @@ def main():
 
     print("Size of conformation matrix", conforms.shape)
 
-    if not args.skip_sampling_precision:
-        # get_rmsds_matrix modifies conforms, so save it to a file and restore
-        # afterwards (so that we retain the original IMP orientation)
-        numpy.save("conforms", conforms)
+    # get_rmsds_matrix modifies conforms, so save it to a file and restore
+    # afterwards (so that we retain the original IMP orientation)
+    numpy.save("conforms", conforms)
+
+    if not os.path.isfile("Distances_Matrix.data.npy"):
+        print("Computing RMSD matrix...")
         inner_data = rmsd_calculation.get_rmsds_matrix(
-                conforms, args.mode, args.align, args.cores, symm_groups)
+            conforms, args.mode, args.align, args.cores, symm_groups)
         print("Size of RMSD matrix (flattened):", inner_data.shape)
         del conforms
         conforms = numpy.load("conforms.npy")
         os.unlink('conforms.npy')
+    else:
+        print("Loading saved RMSD matrix")
 
     from pyRMSD.matrixHandler import MatrixHandler
     mHandler = MatrixHandler()


### PR DESCRIPTION
all-by-all RMSD distance matrix is calculated only when sampling_precision calculated is requested. However, I have a use-case where I don't want to calculate sampling precision, but rather have prior information about the cluster threshold. I want to just cluster the models based on this threshold, and obtain the cluster precision. But model precision calculation without doing sampling precision calculation is possibly only when the ```Distances_Matrix.data.npy``` file is already created and contains the RMSD distance matrix.

So, I changed this to the RMSD distance matrix being calculated and stored in ```Distances_Matrix.data.npy``` **always** (irrespective of whether sampling precision calculation is skipped or not), except when the script is being re-run and that file already exists. 