### PR TITLE
Different handling of symmetry groups based on calculator type

### DIFF
--- a/pyext/src/precision_rmsd.py
+++ b/pyext/src/precision_rmsd.py
@@ -53,7 +53,7 @@ def get_particles_from_superposed(
                 fitSymmetryGroups=symm_groups)
 
     check1 = (calculator_name == 'NOSUP_SERIAL_CALCULATOR')
-    check2 = not (symm_groups is None)
+    check2 = symm_groups is not None
     if check1 and check2:
         # superposed calc_coords returned if calc-coords
         # specified while creating the calculator

--- a/pyext/src/precision_rmsd.py
+++ b/pyext/src/precision_rmsd.py
@@ -36,15 +36,29 @@ def get_particles_from_superposed(
             calculator_name,
             conforms)
     else:
-        s1 = parse_symm_groups_for_pyrmsd(symm_groups)
-        calculator = pyRMSD.RMSDCalculator.RMSDCalculator(
-            calculator_name,
-            fittingCoordsets=conforms,
-            calcSymmetryGroups=s1,
-            fitSymmetryGroups=s1)
-
-    rmsd, superposed_fit = calculator.pairwise(
-        0, 1, get_superposed_coordinates=True)
+        if calculator_name == 'NOSUP_SERIAL_CALCULATOR':
+            # calc_symm_groups are enough without any fitting
+            s1 = parse_symm_groups_for_pyrmsd(symm_groups)
+            calculator = pyRMSD.RMSDCalculator.RMSDCalculator(
+                calculator_name,
+                fittingCoordsets=conforms,
+                calculationCoordsets=conforms,
+                calcSymmetryGroups=s1,
+                fitSymmetryGroups=[])
+        else:
+            calculator = pyRMSD.RMSDCalculator.RMSDCalculator(
+                calculator_name,
+                fittingCoordsets=conforms,
+                calcSymmetryGroups=[],
+                fitSymmetryGroups=symm_groups)
+    
+    if calculator_name == 'NOSUP_SERIAL_CALCULATOR':
+        # pairwise returns the superposed calc_coords if specified
+        rmsd, superposed_fit, _calc_fit = calculator.pairwise(
+            0, 1, get_superposed_coordinates=True)
+    else:
+        rmsd, superposed_fit = calculator.pairwise(
+            0, 1, get_superposed_coordinates=True)
     # Get transformation from pyRMSD reference on the first call.
     # This is somewhat inefficient (since we are essentially repeating
     # the pyRMSD calculation) but pyRMSD doesn't appear to make its

--- a/pyext/src/precision_rmsd.py
+++ b/pyext/src/precision_rmsd.py
@@ -51,11 +51,11 @@ def get_particles_from_superposed(
                 fittingCoordsets=conforms,
                 calcSymmetryGroups=[],
                 fitSymmetryGroups=symm_groups)
-    
+
     check1 = (calculator_name == 'NOSUP_SERIAL_CALCULATOR')
     check2 = not (symm_groups is None)
     if check1 and check2:
-        # superposed calc_coords returned if calc-coords 
+        # superposed calc_coords returned if calc-coords
         # specified while creating the calculator
         rmsd, superposed_fit, _calc_fit = calculator.pairwise(
             0, 1, get_superposed_coordinates=True)

--- a/pyext/src/precision_rmsd.py
+++ b/pyext/src/precision_rmsd.py
@@ -52,8 +52,11 @@ def get_particles_from_superposed(
                 calcSymmetryGroups=[],
                 fitSymmetryGroups=symm_groups)
     
-    if calculator_name == 'NOSUP_SERIAL_CALCULATOR':
-        # pairwise returns the superposed calc_coords if specified
+    check1 = (calculator_name == 'NOSUP_SERIAL_CALCULATOR')
+    check2 = not (symm_groups is None)
+    if check1 and check2:
+        # superposed calc_coords returned if calc-coords 
+        # specified while creating the calculator
         rmsd, superposed_fit, _calc_fit = calculator.pairwise(
             0, 1, get_superposed_coordinates=True)
     else:

--- a/pyext/src/rmsd_calculation.py
+++ b/pyext/src/rmsd_calculation.py
@@ -431,12 +431,21 @@ def get_rmsds_matrix(conforms,  mode,  sup,  cores, symm_groups=None):
 
     if symm_groups:
         print("We have ambiguity.")
-        s1 = parse_symm_groups_for_pyrmsd(symm_groups)
-        calculator = pyRMSD.RMSDCalculator.RMSDCalculator(
-            calculator_name,
-            fittingCoordsets=conforms,
-            calcSymmetryGroups=s1,
-            fitSymmetryGroups=s1)
+        if calculator_name == 'NOSUP_OMP_CALCULATOR':
+            # calc_symm_groups are enough without any fitting
+            s1 = parse_symm_groups_for_pyrmsd(symm_groups)
+            calculator = pyRMSD.RMSDCalculator.RMSDCalculator(
+                calculator_name,
+                fittingCoordsets=conforms,
+                calculationCoordsets=conforms,
+                calcSymmetryGroups=s1,
+                fitSymmetryGroups=[])
+        else:
+            calculator = pyRMSD.RMSDCalculator.RMSDCalculator(
+                calculator_name,
+                fittingCoordsets=conforms,
+                calcSymmetryGroups=[],
+                fitSymmetryGroups=symm_groups)
 
     else:
         calculator = pyRMSD.RMSDCalculator.RMSDCalculator(

--- a/test/test_precision_rmsd.py
+++ b/test/test_precision_rmsd.py
@@ -1,0 +1,128 @@
+import IMP
+import IMP.core
+import IMP.atom
+import IMP.test
+import IMP.algebra
+import os
+import numpy as np
+import pyRMSD
+from pyRMSD.matrixHandler import MatrixHandler
+from IMP.sampcon import precision_rmsd as pr
+
+
+class Tests(IMP.test.TestCase):
+    """Test get_particles_from_superposed"""
+
+    def setUp(self):
+        IMP.test.TestCase.setUp(self)
+        IMP.set_log_level(IMP.SILENT)
+        IMP.set_check_level(IMP.NONE)
+
+        self.m = IMP.Model()
+        self.ps = []
+        for i in range(20):
+            self.ps.append(self.setup_p(f'{i}'))
+        protein_skeleton = np.array([[0, 0, 0], [0, 1, 0], 
+                                     [0, 0, 1], [1, 0, 0], 
+                                     [1, 1, 1]])
+        thetas = [0, np.pi / 6, np.pi / 2, np.pi]
+        proteins = [protein_skeleton.copy()]
+        # axis is (1, 0, 0)
+        for i in range(4):
+            t = thetas[i]
+            rot_matrix = np.array([[1, 0, 0], 
+                                   [0, np.cos(t), -np.sin(t)], 
+                                   [0, np.sin(t), np.cos(t)]])
+            proteins.append(np.matmul(rot_matrix, 
+                            protein_skeleton.T).T + (i + 1) * 3)
+        p0, p1, p2, p3, p4 = proteins
+        self.proteins = proteins
+        self.protein_skeleton = protein_skeleton
+        self.coords_trans_rot = [p0, p2]
+        t = np.pi / 3
+        rot_matrix = np.array([[1, 0, 0], 
+                               [0, np.cos(t), -np.sin(t)], 
+                               [0, np.sin(t), np.cos(t)]])
+        self.coords_symm_2_trans_rot = [np.concatenate([p0, p2], axis=0),
+                                        np.matmul(rot_matrix, 
+                                        np.concatenate([p2, p0], axis=0).T).T]
+        self.coords_symm_n = [np.concatenate([p0, p2, p3, p4], axis=0),
+                              np.concatenate([p4, p0, p3, p2], axis=0)]
+
+    def setup_p(self, name):
+        p = self.m.add_particle(str(name))
+        p = IMP.core.XYZR.setup_particle(self.m, p)
+        return p
+
+    def extract_coords(self, n):
+        coords = []
+        for i in range(n):
+            coords.append(np.array(self.ps[i].get_coordinates()))
+        return coords
+
+    def test_get_particles_from_superposed_align(self):
+        """Check get_particles_from_superposed with alignment"""
+        c1, c2 = self.coords_trans_rot
+        rmsd, ps, trans = pr.get_particles_from_superposed(c2, c1, 
+                                                           True, 
+                                                           self.ps[:5], 
+                                                           None, 
+                                                           None)
+        self.assertAlmostEqual(rmsd, 0, delta=1e-5)
+        coords = self.extract_coords(5)
+        np.testing.assert_allclose(np.array(coords), 
+                                   self.protein_skeleton, rtol=0, atol=1e-5)
+
+    def test_get_particles_from_superposed(self):
+        """Check get_particles_from_superposed without alignment"""
+        c1, c2 = self.coords_trans_rot
+        rmsd, ps, trans = pr.get_particles_from_superposed(c2, c1, 
+                                                           False, 
+                                                           self.ps[:5], 
+                                                           None, 
+                                                           None)
+        self.assertGreater(rmsd, 0)
+
+    def test_get_particles_from_superposed_align_symm(self):
+        """Check get_particles_from_superposed with alignment and symm"""
+        c1, c2 = self.coords_symm_2_trans_rot
+        rmsd, ps, trans = pr.get_particles_from_superposed(c2, c1, 
+                                                           True, self.ps[:10], 
+                                                           None,
+                                                           [[[0, 5], [1, 6], [2, 7],[3, 8], [4, 9]]])
+        self.assertAlmostEqual(rmsd, 0, delta=1e-5)
+        # coords = self.extract_coords(10)
+        # np.testing.assert_allclose(np.array(coords)[5:, :], self.protein_skeleton, rtol=0, atol=1e-5)
+        c1, c2 = self.coords_symm_n
+        rmsd, ps, trans = pr.get_particles_from_superposed(c2, c1, 
+                                                           True, self.ps[:20], 
+                                                           None,
+                                                            [[[0, 5, 10, 15], [1, 6, 11, 16],
+                                                              [2, 7, 12, 17],[3, 8, 13, 18],
+                                                              [4, 9, 14, 19]]])
+        self.assertAlmostEqual(rmsd, 0, delta=1e-5)
+        # coords = self.extract_coords(20)
+        # np.testing.assert_allclose(np.array(coords)[5:10, :], self.protein_skeleton, rtol=0, atol=1e-5)
+
+    def test_get_particles_from_superposed_symm(self):
+        """Check get_particles_from_superposed without alignment and symm"""
+        c1, c2 = self.coords_symm_2_trans_rot
+        rmsd, ps, trans = pr.get_particles_from_superposed(c2, c1, 
+                                                           False, self.ps[:10], 
+                                                           None,
+                                                           [[[0, 5], [1, 6], [2, 7],[3, 8], [4, 9]]])
+        self.assertGreater(rmsd, 0)
+        c1, c2 = self.coords_symm_n
+        rmsd, ps, trans = pr.get_particles_from_superposed(c2, c1, 
+                                                           False, self.ps[:20], 
+                                                           None,
+                                                           [[[0, 5, 10, 15], [1, 6, 11, 16],
+                                                            [2, 7, 12, 17],[3, 8, 13, 18],
+                                                            [4, 9, 14, 19]]])
+        self.assertAlmostEqual(rmsd, 0, delta=1e-5)
+        coords = self.extract_coords(20)
+        np.testing.assert_allclose(np.array(coords)[5:10, :], self.protein_skeleton, rtol=0, atol=1e-5)
+
+
+if __name__ == '__main__':
+    IMP.test.main()

--- a/test/test_precision_rmsd.py
+++ b/test/test_precision_rmsd.py
@@ -100,7 +100,7 @@ class Tests(IMP.test.TestCase):
               [1, 6, 11, 16],
               [2, 7, 12, 17],
               [3, 8, 13, 18],
-              [4, 9, 14, 19]]])
+              [4, 9, 14, 19]]]
         rmsd, ps, trans = pr.get_particles_from_superposed(c2, c1,
                                                            True,
                                                            self.ps[:20],

--- a/test/test_precision_rmsd.py
+++ b/test/test_precision_rmsd.py
@@ -3,10 +3,7 @@ import IMP.core
 import IMP.atom
 import IMP.test
 import IMP.algebra
-import os
 import numpy as np
-import pyRMSD
-from pyRMSD.matrixHandler import MatrixHandler
 from IMP.sampcon import precision_rmsd as pr
 
 
@@ -22,30 +19,31 @@ class Tests(IMP.test.TestCase):
         self.ps = []
         for i in range(20):
             self.ps.append(self.setup_p('{' + str(i) + '}'))
-        protein_skeleton = np.array([[0, 0, 0], [0, 1, 0], 
-                                     [0, 0, 1], [1, 0, 0], 
+        protein_skeleton = np.array([[0, 0, 0], [0, 1, 0],
+                                     [0, 0, 1], [1, 0, 0],
                                      [1, 1, 1]])
         thetas = [0, np.pi / 6, np.pi / 2, np.pi]
         proteins = [protein_skeleton.copy()]
         # axis is (1, 0, 0)
         for i in range(4):
             t = thetas[i]
-            rot_matrix = np.array([[1, 0, 0], 
-                                   [0, np.cos(t), -np.sin(t)], 
+            rot_matrix = np.array([[1, 0, 0],
+                                   [0, np.cos(t), -np.sin(t)],
                                    [0, np.sin(t), np.cos(t)]])
-            proteins.append(np.matmul(rot_matrix, 
+            proteins.append(np.matmul(rot_matrix,
                             protein_skeleton.T).T + (i + 1) * 3)
         p0, p1, p2, p3, p4 = proteins
         self.proteins = proteins
         self.protein_skeleton = protein_skeleton
         self.coords_trans_rot = [p0, p2]
         t = np.pi / 3
-        rot_matrix = np.array([[1, 0, 0], 
-                               [0, np.cos(t), -np.sin(t)], 
+        rot_matrix = np.array([[1, 0, 0],
+                               [0, np.cos(t), -np.sin(t)],
                                [0, np.sin(t), np.cos(t)]])
         self.coords_symm_2_trans_rot = [np.concatenate([p0, p2], axis=0),
-                                        np.matmul(rot_matrix, 
-                                        np.concatenate([p2, p0], axis=0).T).T]
+                                        np.matmul(rot_matrix,
+                                        np.concatenate([p2, p0], 
+                                                       axis=0).T).T]
         self.coords_symm_n = [np.concatenate([p0, p2, p3, p4], axis=0),
                               np.concatenate([p4, p0, p3, p2], axis=0)]
 
@@ -61,67 +59,84 @@ class Tests(IMP.test.TestCase):
         return coords
 
     def test_get_particles_from_superposed_align(self):
-        """Check get_particles_from_superposed with alignment"""
+        """Check get_particles_from_superposed with align"""
         c1, c2 = self.coords_trans_rot
-        rmsd, ps, trans = pr.get_particles_from_superposed(c2, c1, 
-                                                           True, 
-                                                           self.ps[:5], 
-                                                           None, 
+        rmsd, ps, trans = pr.get_particles_from_superposed(c2, c1,
+                                                           True,
+                                                           self.ps[:5],
+                                                           None,
                                                            None)
         self.assertAlmostEqual(rmsd, 0, delta=1e-5)
         coords = self.extract_coords(5)
-        np.testing.assert_allclose(np.array(coords), 
-                                   self.protein_skeleton, rtol=0, atol=1e-5)
+        np.testing.assert_allclose(np.array(coords),
+                                   self.protein_skeleton,
+                                   rtol=0, atol=1e-5)
 
     def test_get_particles_from_superposed(self):
-        """Check get_particles_from_superposed without alignment"""
+        """Check get_particles_from_superposed without align"""
         c1, c2 = self.coords_trans_rot
-        rmsd, ps, trans = pr.get_particles_from_superposed(c2, c1, 
-                                                           False, 
-                                                           self.ps[:5], 
-                                                           None, 
+        rmsd, ps, trans = pr.get_particles_from_superposed(c2, c1,
+                                                           False,
+                                                           self.ps[:5],
+                                                           None,
                                                            None)
         self.assertGreater(rmsd, 0)
 
     def test_get_particles_from_superposed_align_symm(self):
-        """Check get_particles_from_superposed with alignment and symm"""
+        """Check get_particles_from_superposed with align and symm"""
         c1, c2 = self.coords_symm_2_trans_rot
-        rmsd, ps, trans = pr.get_particles_from_superposed(c2, c1, 
-                                                           True, self.ps[:10], 
+        rmsd, ps, trans = pr.get_particles_from_superposed(c2, c1,
+                                                           True,
+                                                           self.ps[:10],
                                                            None,
-                                                           [[[0, 5], [1, 6], [2, 7],[3, 8], [4, 9]]])
+                                                           [[[0, 5],
+                                                             [1, 6],
+                                                             [2, 7],
+                                                             [3, 8],
+                                                             [4, 9]]])
         self.assertAlmostEqual(rmsd, 0, delta=1e-5)
-        # coords = self.extract_coords(10)
-        # np.testing.assert_allclose(np.array(coords)[5:, :], self.protein_skeleton, rtol=0, atol=1e-5)
         c1, c2 = self.coords_symm_n
-        rmsd, ps, trans = pr.get_particles_from_superposed(c2, c1, 
-                                                           True, self.ps[:20], 
+        s = [[[0, 5, 10, 15],
+              [1, 6, 11, 16],
+              [2, 7, 12, 17],
+              [3, 8, 13, 18],
+              [4, 9, 14, 19]]])
+        rmsd, ps, trans = pr.get_particles_from_superposed(c2, c1,
+                                                           True,
+                                                           self.ps[:20],
                                                            None,
-                                                            [[[0, 5, 10, 15], [1, 6, 11, 16],
-                                                              [2, 7, 12, 17],[3, 8, 13, 18],
-                                                              [4, 9, 14, 19]]])
+                                                           s)
         self.assertAlmostEqual(rmsd, 0, delta=1e-5)
-        # coords = self.extract_coords(20)
-        # np.testing.assert_allclose(np.array(coords)[5:10, :], self.protein_skeleton, rtol=0, atol=1e-5)
 
     def test_get_particles_from_superposed_symm(self):
-        """Check get_particles_from_superposed without alignment and symm"""
+        """Check get_particles_from_superposed without align and symm"""
         c1, c2 = self.coords_symm_2_trans_rot
-        rmsd, ps, trans = pr.get_particles_from_superposed(c2, c1, 
-                                                           False, self.ps[:10], 
+        rmsd, ps, trans = pr.get_particles_from_superposed(c2, c1,
+                                                           False,
+                                                           self.ps[:10],
                                                            None,
-                                                           [[[0, 5], [1, 6], [2, 7],[3, 8], [4, 9]]])
+                                                           [[[0, 5],
+                                                             [1, 6],
+                                                             [2, 7],
+                                                             [3, 8],
+                                                             [4, 9]]])
         self.assertGreater(rmsd, 0)
         c1, c2 = self.coords_symm_n
-        rmsd, ps, trans = pr.get_particles_from_superposed(c2, c1, 
-                                                           False, self.ps[:20], 
+        s = [[[0, 5, 10, 15],
+              [1, 6, 11, 16],
+              [2, 7, 12, 17],
+              [3, 8, 13, 18],
+              [4, 9, 14, 19]]]
+        rmsd, ps, trans = pr.get_particles_from_superposed(c2, c1,
+                                                           False,
+                                                           self.ps[:20],
                                                            None,
-                                                           [[[0, 5, 10, 15], [1, 6, 11, 16],
-                                                            [2, 7, 12, 17],[3, 8, 13, 18],
-                                                            [4, 9, 14, 19]]])
+                                                           s)
         self.assertAlmostEqual(rmsd, 0, delta=1e-5)
         coords = self.extract_coords(20)
-        np.testing.assert_allclose(np.array(coords)[5:10, :], self.protein_skeleton, rtol=0, atol=1e-5)
+        np.testing.assert_allclose(np.array(coords)[5:10, :],
+                                   self.protein_skeleton, rtol=0, 
+                                   atol=1e-5)
 
 
 if __name__ == '__main__':

--- a/test/test_precision_rmsd.py
+++ b/test/test_precision_rmsd.py
@@ -21,7 +21,7 @@ class Tests(IMP.test.TestCase):
         self.m = IMP.Model()
         self.ps = []
         for i in range(20):
-            self.ps.append(self.setup_p(f'{i}'))
+            self.ps.append(self.setup_p('{' + str(i) + '}'))
         protein_skeleton = np.array([[0, 0, 0], [0, 1, 0], 
                                      [0, 0, 1], [1, 0, 0], 
                                      [1, 1, 1]])

--- a/test/test_precision_rmsd.py
+++ b/test/test_precision_rmsd.py
@@ -42,7 +42,7 @@ class Tests(IMP.test.TestCase):
                                [0, np.sin(t), np.cos(t)]])
         self.coords_symm_2_trans_rot = [np.concatenate([p0, p2], axis=0),
                                         np.matmul(rot_matrix,
-                                        np.concatenate([p2, p0], 
+                                        np.concatenate([p2, p0],
                                                        axis=0).T).T]
         self.coords_symm_n = [np.concatenate([p0, p2, p3, p4], axis=0),
                               np.concatenate([p4, p0, p3, p2], axis=0)]
@@ -135,7 +135,7 @@ class Tests(IMP.test.TestCase):
         self.assertAlmostEqual(rmsd, 0, delta=1e-5)
         coords = self.extract_coords(20)
         np.testing.assert_allclose(np.array(coords)[5:10, :],
-                                   self.protein_skeleton, rtol=0, 
+                                   self.protein_skeleton, rtol=0,
                                    atol=1e-5)
 
 


### PR DESCRIPTION
Given the `NOSUP` calculator (`align = False`), since we have the same coordinate sets for fitting and calculation, it is much faster to only parse the calculation symmetry groups (in C) rather than the equivalent fit symmetry groups (in python). This is assuming they are similar otherwise i.e. no other fitting steps are done in `NOSUP` that depend on the symmetry groups (the COM translation done in `NOSUP`, if I understand correctly, does not depend on the symmetry groups).

For the other calculator,  after the pyRMSD update, we no longer need to separately parse multi-unit symmetry groups into 2-element units while using the fitsymmetry groups.

(This may require the github-workflow to use the updated pyRMSD code which may require a release so that conda-forge can install in the workflow)